### PR TITLE
Buckshot damage buff

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -23,7 +23,7 @@
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
-	damage = rand(20,30)
+	damage = rand(20,35)
 
 /obj/item/projectile/bullet/pellet/weak
 	damage = 3
@@ -97,7 +97,7 @@
 
 
 /obj/item/projectile/bullet/mime
-	damage = 20
+	damage = 30
 
 /obj/item/projectile/bullet/mime/on_hit(var/atom/target, var/blocked = 0)
 	if(istype(target, /mob/living/carbon))


### PR DESCRIPTION
 Buckshot pellet damage upped from 15 to a random chance of 20-35

Ideally this will make buckshot a decent deal stronger and less of a pushover joke munition that's removed in favor of darts/incind 9/10 times

(Also, makes the Mime mech gun actually do more damage than the silenced pistol. Not sure why this wasn't already the case)